### PR TITLE
sm8250-common: define vendor_sysfs_battery_supply type

### DIFF
--- a/sepolicy/vendor/file.te
+++ b/sepolicy/vendor/file.te
@@ -3,6 +3,7 @@ type vendor_persist_camera_file, file_type, vendor_persist_type;
 
 # Battery
 type vendor_sysfs_battery, fs_type, sysfs_type;
+type vendor_sysfs_battery_supply, fs_type, sysfs_type;
 
 # Cutback
 type cutback_data_file, file_type, data_file_type;


### PR DESCRIPTION
necessary after 0499e907b0950bb0f66352885b866809ee9e4fce